### PR TITLE
Add directories to .gitignore #4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,16 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+/.env
+/vendor/
+/tmp/
+/public/
+/log/
+/lib/
+/bin/
+/config/environments
+/config/initializes
+/config/locales
+/config/webpack
+.devcontainer


### PR DESCRIPTION
why
管理不要なファイル/ディレクトリをgitの管理対象から外すため

what
.devcontainer、.envなどを.gitignoreに追加