### PR TITLE
Remove config/webpack from .gitignore #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,6 @@ yarn-debug.log*
 /lib/
 /config/initializes
 /config/locales
-/config/webpack
 .devcontainer
 .DS_Store
 /config/database.yml

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -1,0 +1,5 @@
+process.env.NODE_ENV = process.env.NODE_ENV || 'development'
+
+const environment = require('./environment')
+
+module.exports = environment.toWebpackConfig()

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,0 +1,3 @@
+const { environment } = require('@rails/webpacker')
+
+module.exports = environment

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -1,0 +1,5 @@
+process.env.NODE_ENV = process.env.NODE_ENV || 'production'
+
+const environment = require('./environment')
+
+module.exports = environment.toWebpackConfig()

--- a/config/webpack/test.js
+++ b/config/webpack/test.js
@@ -1,0 +1,5 @@
+process.env.NODE_ENV = process.env.NODE_ENV || 'development'
+
+const environment = require('./environment')
+
+module.exports = environment.toWebpackConfig()


### PR DESCRIPTION
why

- capistranoでのデプロイでwebpackが必要なため

what

- config/webpack 配下のファイルを.gitignoreから除外