### PR TITLE
Use environment variable for ssh-key #2

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -3,7 +3,7 @@ server '13.231.42.225', user: "naoya", roles: %w(web db app)
 set :ssh_options, {
   port: 22,
   user: "naoya", # overrides user setting above
-  keys: %w(~/.ssh/organic_key_rsa),
+  keys: ["#{ENV.fetch('PRODUCTION_SSH_KEY')}"],
   forward_agent: true,
   auth_methods: %w(publickey),
 }


### PR DESCRIPTION
why

- circleci上のssh-keyであるため

what

- .circleci/config.ymlで書いたfingerprintsと対応するkeyを環境変数に設定