### PR TITLE
Specify Gemfile on unicorn #30

### DIFF
--- a/config/unicorn/production.rb
+++ b/config/unicorn/production.rb
@@ -10,6 +10,8 @@ $listen = File.expand_path 'tmp/sockets/unicorn.sock', $app_dir
 $pid = File.expand_path 'tmp/pids/unicorn.pid', $app_dir
 # エラーログを吐き出すファイルのディレクトリ
 $std_log = File.expand_path 'log/unicorn.log', $app_dir
+# Gemfileの場所を指定
+ENV['BUNDLE_GEMFILE'] = $app_dir + "/Gemfile"
 
 # 上記で設定したものが適応されるよう定義
 worker_processes  $worker


### PR DESCRIPTION
why

- unicorn上で正しいGemfileの場所を指定できていないため。

what

- config/unicorn/production.rb に正しいGemfileの場所を指定