### PR TITLE
Enable store edit #32

### DIFF
--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -17,6 +17,20 @@ class StoresController < ApplicationController
     end
   end
 
+  def edit
+    @store = Store.find(params[:id])
+  end
+
+  def update
+    @store = Store.find(params[:id])
+    if @store.update(store_params)
+      flash[:success] = "レストランの情報を更新しました。"
+      redirect_to @store
+    else
+      render 'edit'
+    end
+  end
+
   private
 
   def store_params

--- a/app/views/stores/_form.html.erb
+++ b/app/views/stores/_form.html.erb
@@ -1,0 +1,25 @@
+<%= form_with(model: @store, local: true) do |f| %>
+  <%= render 'shared/error_messages' %>
+  <%= f.label :name, "レストラン名" %>
+  <%= f.text_field :name %>
+
+  <%= f.label :genre, "ジャンル" %>
+  <%= f.text_field :genre %>
+
+  <%= f.label :phone, "電話番号" %>
+  <%= f.telephone_field :phone %>
+
+  <%= f.label :access, "アクセス" %>
+  <%= f.text_field :access %>
+
+  <%= f.label :hour, "営業時間" %>
+  <%= f.text_field :hour %>
+
+  <%= f.label :website, "お店URL" %>
+  <%= f.text_field :website %>
+
+  <%= f.label :address, "住所" %>
+  <%= f.text_field :address %>
+
+  <%= f.submit yield(:button_text), class: "btn btn-primary" %>
+<% end %>

--- a/app/views/stores/edit.html.erb
+++ b/app/views/stores/edit.html.erb
@@ -1,0 +1,10 @@
+<% provide(:title, 'レストラン情報更新') %>
+<% provide(:button_text, '変更を保存') %>
+
+<h1>レストラン情報更新</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= render 'form' %>
+  </div>
+</div>

--- a/app/views/stores/new.html.erb
+++ b/app/views/stores/new.html.erb
@@ -1,32 +1,9 @@
 <% provide(:title, 'レストラン新規登録') %>
+<% provide(:button_text, 'レストラン新規登録') %>
 <h1>レストラン新規登録</h1>
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
-    <%= form_with(model: @store, local: true) do |f| %>
-      <%= render 'shared/error_messages' %>
-      <%= f.label :name, "レストラン名" %>
-      <%= f.text_field :name %>
-
-      <%= f.label :genre, "ジャンル" %>
-      <%= f.text_field :genre %>
-
-      <%= f.label :phone, "電話番号" %>
-      <%= f.telephone_field :phone %>
-
-      <%= f.label :access, "アクセス" %>
-      <%= f.text_field :access %>
-
-      <%= f.label :hour, "営業時間" %>
-      <%= f.text_field :hour %>
-
-      <%= f.label :website, "お店URL" %>
-      <%= f.text_field :website %>
-
-      <%= f.label :address, "住所" %>
-      <%= f.text_field :address %>
-
-      <%= f.submit "新規登録", class: "btn btn-primary" %>
-    <% end %>
+    <%= render 'form' %>
   </div>
 </div>

--- a/spec/features/stores_spec.rb
+++ b/spec/features/stores_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "Stores", type: :feature do
     let(:store) { FactoryBot.build(:store) }
 
     scenario "valid store registration" do
+      # ストア登録
       visit store_registration_path
       fill_in 'store_name',    with: store.name
       fill_in 'store_genre',   with: store.genre
@@ -16,32 +17,80 @@ RSpec.feature "Stores", type: :feature do
       click_on '新規登録'
       # ページタイトルの確認
       expect(page).to have_title "#{store.name} | Organic Table"
-
-      # 新規登録成功時のフラッシュの確認
+      # フラッシュの確認
       expect(page).to have_selector(".alert-success", text: "A new restaurant has been registered")
+      # ストア情報更新
+      store = Store.first
+      visit edit_store_path(store)
+      fill_in 'store_name',    with: "new_name"
+      fill_in 'store_genre',   with: "new_genre"
+      fill_in 'store_phone',   with: "new_phone"
+      fill_in 'store_access',  with: "new_access"
+      fill_in 'store_hour',    with: "new_hour"
+      fill_in 'store_website', with: "new_website"
+      fill_in 'store_address', with: "new_address"
+      click_on '変更を保存'
+      # 変更が成功しているか確認
+      store.reload
+      expect(store.name).to eq "new_name"
+      expect(store.genre).to eq "new_genre"
+      expect(store.phone).to eq "new_phone"
+      expect(store.access).to eq "new_access"
+      expect(store.hour).to eq "new_hour"
+      expect(store.website).to eq "new_website"
+      expect(store.address).to eq "new_address"
+      # ページタイトルの確認
+      expect(page).to have_title "new_name | Organic Table"
+      # フラッシュの確認
+      expect(page).to have_selector ".alert-success", text: ""
     end
   end
 
   context "with invalid values" do
-    let(:store) { FactoryBot.build(:store) }
+    context "#create" do
+      let(:store) { FactoryBot.build(:store) }
 
-    scenario "invalid store registration" do
-      visit store_registration_path
-      fill_in 'store_name',    with: ""
-      fill_in 'store_genre',   with: store.genre
-      fill_in 'store_phone',   with: store.phone
-      fill_in 'store_access',  with: store.access
-      fill_in 'store_hour',    with: store.hour
-      fill_in 'store_website', with: store.website
-      fill_in 'store_address', with: store.address
-      click_on '新規登録'
-      # ページタイトルの確認
-      expect(page).to have_title "レストラン新規登録 | Organic Table"
+      scenario "invalid store registration" do
+        visit store_registration_path
+        fill_in 'store_name',    with: ""
+        fill_in 'store_genre',   with: store.genre
+        fill_in 'store_phone',   with: store.phone
+        fill_in 'store_access',  with: store.access
+        fill_in 'store_hour',    with: store.hour
+        fill_in 'store_website', with: store.website
+        fill_in 'store_address', with: store.address
+        click_on '新規登録'
+        # ページタイトルの確認
+        expect(page).to have_title "レストラン新規登録 | Organic Table"
 
-      # エラーの検証
-      expect(page).to have_selector("#error_explanation")
-      expect(page).to have_selector(".alert-danger", text: "The form contains 1 error.")
-      expect(page).to have_content("Name can't be blank")
+        # エラーの検証
+        expect(page).to have_selector("#error_explanation")
+        expect(page).to have_selector(".alert-danger", text: "The form contains 1 error.")
+        expect(page).to have_content("Name can't be blank")
+      end
+    end
+
+    context "#edit" do
+      let(:store) { FactoryBot.create(:store) }
+
+      scenario "invalid store edit" do
+        visit edit_store_path(store)
+        fill_in 'store_name',    with: ""
+        fill_in 'store_genre',   with: store.genre
+        fill_in 'store_phone',   with: store.phone
+        fill_in 'store_access',  with: store.access
+        fill_in 'store_hour',    with: store.hour
+        fill_in 'store_website', with: store.website
+        fill_in 'store_address', with: store.address
+        click_on '変更を保存'
+        # ページタイトルの確認
+        expect(page).to have_title "レストラン情報更新 | Organic Table"
+
+        # エラーの検証
+        expect(page).to have_selector("#error_explanation")
+        expect(page).to have_selector(".alert-danger", text: "The form contains 1 error.")
+        expect(page).to have_content("Name can't be blank")
+      end
     end
   end
 end

--- a/spec/requests/stores_spec.rb
+++ b/spec/requests/stores_spec.rb
@@ -61,4 +61,20 @@ RSpec.describe "Store", type: :request do
       end
     end
   end
+
+  describe "GET #edit" do
+    let(:store) { create(:store) }
+
+    before do
+      get edit_store_url(store)
+    end
+
+    it "returns http success" do
+      expect(response).to have_http_status 200
+    end
+
+    it "has the correct title" do
+      expect(response.body).to include "レストラン情報更新 | Organic Table"
+    end
+  end
 end


### PR DESCRIPTION
why

- 必須機能のため

what

- edit, updateアクションの追加

- 入力フォームのパーシャル化

- テストの追加