### PR TITLE
Add links to store registration and edit #35

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,9 +19,10 @@
         <%= link_to "OrganicTable", '#', id: "logo" %>
         <nav>
           <ul class="nav navbar-nav navbar-right">
-            <li><%= link_to "Home",   '#' %></li>
-            <li><%= link_to "About",   '#' %></li>
-            <li><%= link_to "Log in", '#' %></li>
+            <li><%= link_to "ストア登録", store_registration_path %></li>
+            <li><%= link_to "Home",     '#' %></li>
+            <li><%= link_to "About",    about_path %></li>
+            <li><%= link_to "Log in",   '#' %></li>
           </ul>
         </nav>
       </div>

--- a/app/views/stores/show.html.erb
+++ b/app/views/stores/show.html.erb
@@ -1,2 +1,3 @@
 <% provide(:title, @store.name) %>
 <%= @store.name %>, <%= @store.address %>
+<%= link_to "ストア編集", edit_store_path(params[:id]) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  get 'static_pages/about'
+  get '/about', to: 'static_pages#about'
   get '/store_registration', to: 'stores#new'
   resources :stores
 end

--- a/spec/features/stores_spec.rb
+++ b/spec/features/stores_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Stores", type: :feature do
       expect(page).to have_selector(".alert-success", text: "A new restaurant has been registered")
       # ストア情報更新
       store = Store.first
-      visit edit_store_path(store)
+      click_on 'ストア編集'
       fill_in 'store_name',    with: "new_name"
       fill_in 'store_genre',   with: "new_genre"
       fill_in 'store_phone',   with: "new_phone"


### PR DESCRIPTION
why

- 操作性向上のため

what

- 新規登録ページをヘッダーに追加

- 編集ページをストア詳細ページに追加