### PR TITLE
Add description to stores #43

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -185,6 +185,10 @@ input {
   margin-left: 30px;
 }
 
+.store_description {
+  margin: 10px 0 0 40px;
+}
+
 .pagination>li>a {          
   border: none;
   color: #696969;

--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -39,6 +39,6 @@ class StoresController < ApplicationController
 
   def store_params
     params.require(:store).permit(:name, :genre, :phone, :access,
-                                  :hour, :website, :address, :image)
+                                  :hour, :website, :address, :description, :image)
   end
 end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -6,10 +6,11 @@ class Store < ApplicationRecord
   validates :hour, presence: true, length: { maximum: 50 }
   validates :website, presence: true, length: { maximum: 100 }
   validates :address, presence: true, length: { maximum: 50 }
+  validates :description, presence: true, length: { maximum: 100 }
   has_one_attached :image
   validate :image_presence
 
   def image_presence
-    errors.add(:image, "can't be blank") unless image.attached?
+    errors.add(:image, "を添付してください") unless image.attached?
   end
 end

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,7 +1,7 @@
 <% if @store.errors.any? %>
   <div id="error_explanation">
     <div class="alert alert-danger">
-      The form contains <%= pluralize(@store.errors.count, "error") %>.
+      <%= @store.errors.count %>つエラーがあります。
     </div>
     <ul>
     <% @store.errors.full_messages.each do |msg| %>

--- a/app/views/stores/_form.html.erb
+++ b/app/views/stores/_form.html.erb
@@ -21,8 +21,11 @@
   <%= f.label :address, "住所" %>
   <%= f.text_field :address %>
 
+  <%= f.label :description, "レストラン概要" %>
+  <%= f.text_field :description %>
+
   <%= f.label :image, "レストラン画像" %>
-  <%= f.file_field :image%>
+  <%= f.file_field :image %>
 
   <%= f.submit yield(:button_text), class: "btn btn-primary" %>
 <% end %>

--- a/app/views/stores/_store_info.html.erb
+++ b/app/views/stores/_store_info.html.erb
@@ -4,9 +4,12 @@
       <%= image_tag store.image.variant(resize_to_fill: [200,200]) %>
     </div>
 
-    <div class="store_description">
+    <div class="store_info">
       <div class="store_name">
         <%= link_to "#{store.name}", store_path(store) %> <span><%= store.genre %></span>
+      </div>
+      <div class="store_description">
+        <%= store.description %>
       </div>
     </div>
   </div>

--- a/app/views/stores/show.html.erb
+++ b/app/views/stores/show.html.erb
@@ -1,4 +1,5 @@
 <% provide(:title, @store.name) %>
 <%= @store.name %>, <%= @store.address %>
 <%= image_tag url_for(@store.image) if @store.image.attached? %>
+<%= @store.description %>
 <%= link_to "ストア編集", edit_store_path(params[:id]) %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,5 +34,6 @@ module Organictable
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
     config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
   end
 end

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -1,0 +1,15 @@
+ja:
+  activerecord:
+    models:
+      store: ストア
+    attributes:
+      store:
+        name: 名前
+        genre: ジャンル
+        phone: 電話番号
+        access: アクセス
+        hour: 営業時間
+        website: ウェブサイト
+        address: 住所
+        description: レストラン概要
+        image: 店画像

--- a/db/migrate/20210122073719_add_description_to_stores.rb
+++ b/db/migrate/20210122073719_add_description_to_stores.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToStores < ActiveRecord::Migration[6.0]
+  def change
+    add_column :stores, :description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_20_075008) do
+ActiveRecord::Schema.define(version: 2021_01_22_073719) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2020_11_20_075008) do
     t.string "address"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "description"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,7 +5,8 @@ store = Store.new(name: "Example User",
              access: "中央駅東口徒歩5分",
              hour: "10:00 ~ 22:00",
              website: "example.com",
-             address: "東京都中区1-2-3")
+             address: "東京都中区1-2-3",
+             description: "手軽な価格で本格的なフレンチ料理が味わえるレストランです")
              
              store.image.attach(io: File.open('app/assets/images/vegetable-3.jpg'), filename: 'vegetable-3.jpg', content_type: 'image/jpg')
             #  image: open("#{Rails.root}/app/assets/images/vegetable-3.jpg"))
@@ -20,6 +21,7 @@ store.save
   hour = "10:00 ~ 22:00"
   website = "example-#{n}.com"
   address = "東京都#{n}番目"
+  description = "#{n}番目のレストランです。さまざまな料理をお手軽な値段でいただけます"
   store = Store.new(
     name: name,
     genre: genre,
@@ -27,7 +29,8 @@ store.save
     access: access,
     hour: hour,
     website: website,
-    address: address
+    address: address,
+    description: description
   )
   store.image.attach(io: File.open('app/assets/images/vegetable-3.jpg'), filename: 'vegetable-3.jpg', content_type: 'image/jpg')
   store.save

--- a/spec/factories/stores.rb
+++ b/spec/factories/stores.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     hour { '10:00 ~ 22:00' }
     website { 'https://example.com' }
     address { '東京都中央区1-2-3' }
+    description { 'オーガニックのレストランです' }
     image { fixture_file_upload(Rails.root.to_s + "/spec/fixtures/files/test_image.jpg") }
   end
 end

--- a/spec/features/stores_index_spec.rb
+++ b/spec/features/stores_index_spec.rb
@@ -5,12 +5,14 @@ RSpec.feature "Stores index", type: :feature do
     FactoryBot.create_list(:store, 10)
   end
 
-  scenario "index including pagination" do
+  scenario "store index info" do
     visit stores_path
     expect(page).to have_title "Organic Table"
     expect(page).to have_css "ul.pagination"
-    Store.page(1).per(5) do |store|
-      expect store.to have_link store.name, href: store_path(store)
+    Store.page(1).per(5).each do |store|
+      expect(page).to have_link store.name, href: store_path(store)
+      expect(page).to have_content store.genre
+      expect(page).to have_content store.description
     end
   end
 end

--- a/spec/features/stores_spec.rb
+++ b/spec/features/stores_spec.rb
@@ -14,6 +14,7 @@ RSpec.feature "Stores feature", type: :feature do
       fill_in 'store_hour',    with: store.hour
       fill_in 'store_website', with: store.website
       fill_in 'store_address', with: store.address
+      fill_in 'store_description', with: store.description
       attach_file("store[image]", "spec/fixtures/files/test_image.jpg")
       click_on '新規登録'
       # ページタイトルの確認
@@ -30,6 +31,7 @@ RSpec.feature "Stores feature", type: :feature do
       fill_in 'store_hour',    with: "new_hour"
       fill_in 'store_website', with: "new_website"
       fill_in 'store_address', with: "new_address"
+      fill_in 'store_description', with: "new_description"
       attach_file("store[image]", "spec/fixtures/files/new_image.jpg")
       click_on '変更を保存'
       # 変更が成功しているか確認
@@ -41,6 +43,7 @@ RSpec.feature "Stores feature", type: :feature do
       expect(store.hour).to eq "new_hour"
       expect(store.website).to eq "new_website"
       expect(store.address).to eq "new_address"
+      expect(store.description).to eq "new_description"
       # 画像が変更されているか確認
       expect(page).to have_selector "img[src$='new_image.jpg']"
       # ページタイトルの確認
@@ -63,6 +66,7 @@ RSpec.feature "Stores feature", type: :feature do
         fill_in 'store_hour',    with: store.hour
         fill_in 'store_website', with: store.website
         fill_in 'store_address', with: store.address
+        fill_in 'store_description', with: store.description
         attach_file("store[image]", "spec/fixtures/files/test_image.jpg")
         click_on '新規登録'
         # ページタイトルの確認
@@ -70,8 +74,8 @@ RSpec.feature "Stores feature", type: :feature do
 
         # エラーの検証
         expect(page).to have_selector("#error_explanation")
-        expect(page).to have_selector(".alert-danger", text: "The form contains 1 error.")
-        expect(page).to have_content("Nameを入力してください")
+        expect(page).to have_selector(".alert-danger", text: "1つエラーがあります。")
+        expect(page).to have_content("名前を入力してください")
       end
     end
 
@@ -87,6 +91,7 @@ RSpec.feature "Stores feature", type: :feature do
         fill_in 'store_hour',    with: store.hour
         fill_in 'store_website', with: store.website
         fill_in 'store_address', with: store.address
+        fill_in 'store_description', with: store.description
         attach_file("store[image]", "spec/fixtures/files/new_image.jpg")
         click_on '変更を保存'
         # ページタイトルの確認
@@ -94,8 +99,8 @@ RSpec.feature "Stores feature", type: :feature do
 
         # エラーの検証
         expect(page).to have_selector("#error_explanation")
-        expect(page).to have_selector(".alert-danger", text: "The form contains 1 error.")
-        expect(page).to have_content("Nameを入力してください")
+        expect(page).to have_selector(".alert-danger", text: "1つエラーがあります。")
+        expect(page).to have_content("名前を入力してください")
       end
     end
   end

--- a/spec/models/store_spec.rb
+++ b/spec/models/store_spec.rb
@@ -54,10 +54,16 @@ RSpec.describe Store, type: :model do
       expect(store.errors[:address]).to include("を入力してください")
     end
 
+    it 'is invalid without a description' do
+      store.description = nil
+      store.valid?
+      expect(store.errors[:description]).to include("を入力してください")
+    end
+
     it 'is invalid without an image' do
       store.image = nil
       store.valid?
-      expect(store.errors[:image]).to include("can't be blank")
+      expect(store.errors[:image]).to include("を添付してください")
     end
   end
 
@@ -96,6 +102,11 @@ RSpec.describe Store, type: :model do
 
     it 'is invalid with a too long address' do
       store.address = "a" * 51
+      expect(store).to be_invalid
+    end
+
+    it 'is invalid with a too long description' do
+      store.description = "a" * 101
       expect(store).to be_invalid
     end
   end


### PR DESCRIPTION
why

- 必須機能のため

what

- storesモデルにdescription属性を追加
- db/seedの追加
- 日本語への対応
- テストの作成